### PR TITLE
fix: add warning about multiple devices (wifi/usb/rs485) when "wrong number of registers read"

### DIFF
--- a/custom_components/must_inverter/__init__.py
+++ b/custom_components/must_inverter/__init__.py
@@ -339,12 +339,15 @@ class MustInverter:
                     _LOGGER.error("error reading modbus data at address %s: %s", start, response)
                 elif len(response.registers) != count:
                     _LOGGER.warning(
-                        "wrong number of registers read at address %s, expected %s, got %s",
+                        "wrong number of registers read at address %s, expected %s, got %s - this usually is caused by concurrent access to modbus (usb/wifi/rs485), please remove other devices",
                         start,
                         count,
                         len(response.registers),
                     )
+                    # Log the actual values received
+                    _LOGGER.debug("Received registers (wrong): %s", response.registers)
                 else:
+                    _LOGGER.debug("Correctly read %s registers from start %s", count, start)
                     for i in range(count):
                         read[start + i] = response.registers[i]
                     self.data.update(register[2](read))


### PR DESCRIPTION
#### read_modbus_data: add warning about multiple devices (wifi/usb/rs485) when "wrong number of registers read"

- I was getting a very high incidence of wrong number of registers read
  - I got both _less_ and _more_ (!!!) registers than asked for
  - I realized my Wifi Module ("Plug14") was interferring
  - Removing the Wifi made it go away
- also add some debugs

`Signed-off-by: Ricardo Pardini <ricardo@pardini.net>`

----

- possibly, this explains @Benj-HaRRison 's problem in #47 
- maybe it would be nice to create an "Issue" (like the serial number one) in this case as well?