### PR TITLE
feat: support for ph1100 series

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ power production, battery status, and more, directly from your Must solar invert
 
 ## Supported Devices
 
-This integration is tested using a Must Solar PV18-3024 VPM (aka PV1800), PV19 / PV1900 EXP Series (4/6KW). However, it should work with other models that use the same communication protocol, such as the PH1800 and EP1800 series.
+This integration is tested using a Must Solar PV18-3024 VPM (aka PV1800), PV19 / PV1900 EXP Series (4/6KW), PH11 / PH1100 EU Series (AC:380V 5-12KW). However, it should work with other models that use the same communication protocol, such as the PH1800 and EP1800 series.
 
 ## Disclaimer
 

--- a/custom_components/must_inverter/__init__.py
+++ b/custom_components/must_inverter/__init__.py
@@ -35,9 +35,14 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     get_sensors_for_model,
     MODEL_PV1900,
+    MODEL_PH1100,
 )
 
 from .mapper import (
+    convert_ph1100_partArr1,
+    convert_ph1100_partArr2,
+    convert_ph1100_partArr3,
+    convert_ph1100_partArr4,
     convert_partArr2,
     convert_partArr3,
     convert_partArr4,
@@ -55,6 +60,7 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SWITCH,
     Platform.BUTTON,
+    Platform.TIME,
 ]
 _LOGGER = logging.getLogger(__name__)
 
@@ -219,7 +225,7 @@ class MustInverter:
 
     @property
     def name(self):
-        return self._entry.options.get(CONF_NAME, self.data.get("InverterMachineType"))
+        return self._entry.options.get(CONF_NAME, self.model)
 
     @property
     def model(self):
@@ -294,26 +300,34 @@ class MustInverter:
         # immediately and the charger stops working afterwards (all registers
         # return zeroes). Requires the grid/batteries/PV to be disconnected and
         # the inverter restarted for it to come back online.
-        # Base register ranges for all models
-        registersAddresses = [
-            # (10000, 10008, convert_partArr1), # Charger Control Messages
-            (10101, 10124, convert_partArr2),  # Charger Control Messages
-            (15201, 15221, convert_partArr3),  # Charger Display Messages
-            (20000, 20016, convert_partArr4),  # Inverter Control Messages
-            (20101, 20214, convert_partArr5),  # Inverter Control Messages
-            (25201, 25279, convert_partArr6),  # Inverter Display Messages
-        ]
+        if self.model == MODEL_PH1100:
+            registersAddresses = [
+                (10102, 10119, convert_ph1100_partArr1),  # Charger Control Messages
+                (15104, 15119, convert_ph1100_partArr2),  # Charger Display Messages
+                (20001, 20003, convert_ph1100_partArr3),  # Inverter Control Messages
+                (25225, 25339, convert_ph1100_partArr4),  # Inverter Display Messages
+            ]
+        else:
+            # Base register ranges for all models
+            registersAddresses = [
+                # (10000, 10008, convert_partArr1), # Charger Control Messages
+                (10101, 10124, convert_partArr2),  # Charger Control Messages
+                (15201, 15221, convert_partArr3),  # Charger Display Messages
+                (20000, 20016, convert_partArr4),  # Inverter Control Messages
+                (20101, 20214, convert_partArr5),  # Inverter Control Messages
+                (25201, 25279, convert_partArr6),  # Inverter Display Messages
+            ]
 
-        # Add PV19-specific register ranges if needed
-        # Keep register ranges for pv separate to not overload the inverter
-        if self.has_extra_registers:
-            registersAddresses.extend(
-                [
-                    (113, 114, convert_battery_status),  # Battery Status (SoC, SoH)
-                    (15207, 15208, convert_pv_data),  # PV1 Data (Current, Power)
-                    (16205, 16208, convert_pv_data),  # PV2 Data (Voltage, Current, Power)
-                ]
-            )
+            # Add PV19-specific register ranges if needed
+            # Keep register ranges for pv separate to not overload the inverter
+            if self.has_extra_registers:
+                registersAddresses.extend(
+                    [
+                        (113, 114, convert_battery_status),  # Battery Status (SoC, SoH)
+                        (15207, 15208, convert_pv_data),  # PV1 Data (Current, Power)
+                        (16205, 16208, convert_pv_data),  # PV2 Data (Voltage, Current, Power)
+                    ]
+                )
 
         read = {}
 
@@ -391,8 +405,8 @@ class MustInverter:
             "identifiers": {(DOMAIN, self.data["InverterSerialNumber"])},
             "name": self.name,
             "manufacturer": "Must Solar",
-            "model": self.data["InverterMachineType"],
-            "hw_version": self.data["InverterHardwareVersion"],
-            "sw_version": self.data["InverterSoftwareVersion"],
+            "model": self.model,
+            "hw_version": self.data.get("InverterHardwareVersion"),
+            "sw_version": self.data.get("InverterSoftwareVersion"),
             "serial_number": self.data["InverterSerialNumber"],
         }

--- a/custom_components/must_inverter/__init__.py
+++ b/custom_components/must_inverter/__init__.py
@@ -225,7 +225,7 @@ class MustInverter:
 
     @property
     def name(self):
-        return self._entry.options.get(CONF_NAME, self.model)
+        return self._entry.options.get(CONF_NAME, self.data.get("InverterMachineType", self.model))
 
     @property
     def model(self):
@@ -405,7 +405,7 @@ class MustInverter:
             "identifiers": {(DOMAIN, self.data["InverterSerialNumber"])},
             "name": self.name,
             "manufacturer": "Must Solar",
-            "model": self.model,
+            "model": self.data.get("InverterMachineType", self.model),
             "hw_version": self.data.get("InverterHardwareVersion"),
             "sw_version": self.data.get("InverterSoftwareVersion"),
             "serial_number": self.data["InverterSerialNumber"],

--- a/custom_components/must_inverter/const.py
+++ b/custom_components/must_inverter/const.py
@@ -253,7 +253,8 @@ PH1100_SENSORS = [
     Sensor(25284, "MainsCTRPhaseCurrent",            0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
     Sensor(25285, "MainsCTSPhaseCurrent",            0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
     Sensor(25286, "MainsCTTPhaseCurrent",            0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
-    Sensor(25287, "MainsPowerCT",                    0.01,    "kW",     Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    # Negating for compatibility with HA home energy management grid power sensor spec
+    Sensor(25287, "MainsPowerCT",                    -0.01,   "kW",     Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
     Sensor(25310, "TotalPvEnergy",                   None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
     Sensor(25312, "TotalLoadEnergy",                 None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
     Sensor(25314, "TotalBatteryChargeEnergy",        None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),

--- a/custom_components/must_inverter/const.py
+++ b/custom_components/must_inverter/const.py
@@ -19,8 +19,9 @@ DEFAULT_SCAN_INTERVAL = 15
 # model constants, needs to be lowercase otherwise hassfest checks fails...
 MODEL_PV1800 = "pv1800"  # Base model
 MODEL_PV1900 = "pv1900"
+MODEL_PH1100 = "ph1100"
 
-SUPPORTED_MODELS = [MODEL_PV1800, MODEL_PV1900]
+SUPPORTED_MODELS = [MODEL_PV1800, MODEL_PV1900, MODEL_PH1100]
 
 
 class Sensor(NamedTuple):
@@ -176,6 +177,94 @@ PV1900_SENSORS = [
     Sensor(16207, "PV2ChargerCurrent",               0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
     Sensor(16208, "PV2ChargerPower",                 None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
 ]
+
+PH1100_SENSORS = [
+    # Charger Control Messages
+    # Don't know what are the ranges for these settings, so skipping for now
+    # Sensor(10102, "BatteryHighFaultVoltage",         0.01,    "V",      Platform.NUMBER,               NumberDeviceClass.VOLTAGE,         True,  ),
+    # Sensor(10103, "BatteryLowFaultVoltage",          0.01,    "V",      Platform.NUMBER,               NumberDeviceClass.VOLTAGE,         True,  ),
+    # Sensor(10104, "BatteryLowRecoverVoltage",        0.01,    "V",      Platform.NUMBER,               NumberDeviceClass.VOLTAGE,         True,  ),
+    # Sensor(10110, "BatteryMinCurrentChargeVoltage",  0.01,    "V",      Platform.NUMBER,               NumberDeviceClass.VOLTAGE,         True,  ),
+    # Sensor(10111, "BatteryMinCurrentChargeCurrent",  0.01,    "A",      Platform.NUMBER,               NumberDeviceClass.CURRENT,         True,  ),
+    Sensor(10117, "BatteryEqualizationInterval",     1,       "day",    Platform.NUMBER,               None,                              True,  ),
+    Sensor(10118, "BatteryEqualizationStartTime",    None,    None,     Platform.TIME,                 None,                              True,  ),
+    Sensor(10119, "BatteryEqualizationEndTime",      None,    None,     Platform.TIME,                 None,                              True,  ),
+    # Charger Display Messages
+    Sensor(15104, "BatteryVoltage",                  0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(15105, "BattCurrent",                     0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(15106, "BattPower",                       None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(15107, "InverterTemperature",             0.1,     "°C",     Platform.SENSOR,               SensorDeviceClass.TEMPERATURE,     True,  ),
+    Sensor(15108, "DcRadiatorTemperature",           0.1,     "°C",     Platform.SENSOR,               SensorDeviceClass.TEMPERATURE,     True,  ),
+    Sensor(15109, "TransformerTemperature",          0.1,     "°C",     Platform.SENSOR,               SensorDeviceClass.TEMPERATURE,     True,  ),
+    Sensor(15110, "AmbientTemperature",              0.1,     "°C",     Platform.SENSOR,               SensorDeviceClass.TEMPERATURE,     True,  ),
+    Sensor(15111, "BatteryTemperature",              0.1,     "°C",     Platform.SENSOR,               SensorDeviceClass.TEMPERATURE,     True,  ),
+    Sensor(15112, "BMSVoltage",                      0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(15113, "BMSCurrent",                      0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(15114, "BMSTemperature",                  0.1,     "°C",     Platform.SENSOR,               SensorDeviceClass.TEMPERATURE,     True,  ),
+    Sensor(15115, "BMSStateOfCharge",                None,    "%",      Platform.SENSOR,               SensorDeviceClass.BATTERY,         True,  ),
+    Sensor(15116, "BMSMaxCVSet",                     0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(15117, "BMSMaxCCSet",                     0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(15118, "BMSDisCVSet",                     0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(15119, "BMSDisCCSet",                     0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    # Inverter Control Messages
+    Sensor(20001, "InverterSerialNumber",            None,    None,     Platform.SENSOR,               None,                              False, ),
+    # Inverter Display Messages
+    Sensor(25225, "PV1Voltage",                      0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25226, "PV1Current",                      0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25227, "PV1Power",                        None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25228, "PV2Voltage",                      0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25229, "PV2Current",                      0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25230, "PV2Power",                        None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25231, "PV3Voltage",                      0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25232, "PV3Current",                      0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25233, "PV3Power",                        None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25234, "PV4Voltage",                      0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25235, "PV4Current",                      0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25236, "PV4Power",                        None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25237, "GridVoltageR",                    0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25238, "GridVoltageS",                    0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25239, "GridVoltageT",                    0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25240, "GridCurrentR",                    0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25241, "GridCurrentS",                    0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25242, "GridCurrentT",                    0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25243, "GridFrequency",                   0.01,    "Hz",     Platform.SENSOR,               SensorDeviceClass.FREQUENCY,       True,  ),
+    Sensor(25244, "PGrid",                           None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25245, "QGrid",                           None,    "var",    Platform.SENSOR,               SensorDeviceClass.REACTIVE_POWER,  True,  ),
+    Sensor(25246, "SGrid",                           None,    "VA",     Platform.SENSOR,               SensorDeviceClass.APPARENT_POWER,  True,  ),
+    Sensor(25247, "InverterVoltageR",                0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25248, "InverterVoltageS",                0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25249, "InverterVoltageT",                0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25250, "InverterCurrentR",                0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25251, "InverterCurrentS",                0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25252, "InverterCurrentT",                0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25253, "InverterFrequency",               0.01,    "Hz",     Platform.SENSOR,               SensorDeviceClass.FREQUENCY,       True,  ),
+    Sensor(25254, "PInverter",                       None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25255, "QInverter",                       None,    "var",    Platform.SENSOR,               SensorDeviceClass.REACTIVE_POWER,  True,  ),
+    Sensor(25256, "SInverter",                       None,    "VA",     Platform.SENSOR,               SensorDeviceClass.APPARENT_POWER,  True,  ),
+    Sensor(25257, "LoadVoltageR",                    0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25258, "LoadVoltageS",                    0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25259, "LoadVoltageT",                    0.1,     "V",      Platform.SENSOR,               SensorDeviceClass.VOLTAGE,         True,  ),
+    Sensor(25260, "LoadCurrentR",                    0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25261, "LoadCurrentS",                    0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25262, "LoadCurrentT",                    0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25263, "PLoad",                           None,    "W",      Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25264, "QLoad",                           None,    "var",    Platform.SENSOR,               SensorDeviceClass.REACTIVE_POWER,  True,  ),
+    Sensor(25265, "SLoad",                           None,    "VA",     Platform.SENSOR,               SensorDeviceClass.APPARENT_POWER,  True,  ),
+    Sensor(25284, "MainsCTRPhaseCurrent",            0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25285, "MainsCTSPhaseCurrent",            0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25286, "MainsCTTPhaseCurrent",            0.1,     "A",      Platform.SENSOR,               SensorDeviceClass.CURRENT,         True,  ),
+    Sensor(25287, "MainsPowerCT",                    0.01,    "kW",     Platform.SENSOR,               SensorDeviceClass.POWER,           True,  ),
+    Sensor(25310, "TotalPvEnergy",                   None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25312, "TotalLoadEnergy",                 None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25314, "TotalBatteryChargeEnergy",        None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25316, "TotalBatteryDischargeEnergy",     None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25318, "TotalInverterChargeEnergy",       None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25320, "TotalInverterDischargeEnergy",    None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25322, "TotalGridChargeEnergy",           None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25324, "TotalGridDischargeEnergy",        None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25336, "TotalMainsChargeEnergyCT",        None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+    Sensor(25338, "TotalMainsDischargeEnergyCT",     None,    "kWh",    Platform.SENSOR,               SensorDeviceClass.ENERGY,          True,  ),
+]
 # fmt: on
 
 OPTIONS = {
@@ -307,6 +396,9 @@ def get_sensors_for_model(model: str) -> list:
     PV1800: Base sensors only
     PV1900: Base sensors + PV2 and extended battery monitoring
     """
+    if model == MODEL_PH1100:
+        return PH1100_SENSORS
+
     if model == MODEL_PV1900:
         return SENSORS_ARRAY + PV1900_SENSORS
     return SENSORS_ARRAY

--- a/custom_components/must_inverter/icons.json
+++ b/custom_components/must_inverter/icons.json
@@ -80,6 +80,9 @@
             "absorbchargercurrent": { "default": "mdi:current-dc" },
             "mpptstate": { "default": "mdi:solar-power" },
             "chargercurrent": { "default": "mdi:current-dc" },
+            "bmscurrent": { "default": "mdi:current-dc" },
+            "bmsmaxccset": { "default": "mdi:current-dc" },
+            "bmsdisccset": { "default": "mdi:current-dc" },
             "chargererrormessage": { "default": "mdi:alert-circle-outline" },
             "chargerwarningmessage": { "default": "mdi:alert-outline" },
             "ratedcurrent": { "default": "mdi:current-dc" },
@@ -94,7 +97,23 @@
             "battcurrent": { "default": "mdi:current-dc" },
             "batterystateofhealth": { "default": "mdi:battery-heart-variant" },
             "pv1chargercurrent": { "default": "mdi:current-dc" },
-            "pv2chargercurrent": { "default": "mdi:current-dc" }
+            "pv2chargercurrent": { "default": "mdi:current-dc" },
+            "pv1current": { "default": "mdi:current-dc" },
+            "pv2current": { "default": "mdi:current-dc" },
+            "pv3current": { "default": "mdi:current-dc" },
+            "pv4current": { "default": "mdi:current-dc" },
+            "gridcurrentr": { "default": "mdi:current-ac" },
+            "gridcurrents": { "default": "mdi:current-ac" },
+            "gridcurrentt": { "default": "mdi:current-ac" },
+            "invertercurrentr": { "default": "mdi:current-ac" },
+            "invertercurrents": { "default": "mdi:current-ac" },
+            "invertercurrentt": { "default": "mdi:current-ac" },
+            "loadcurrentr": { "default": "mdi:current-ac" },
+            "loadcurrents": { "default": "mdi:current-ac" },
+            "loadcurrentt": { "default": "mdi:current-ac" },
+            "mainsctrphasecurrent": { "default": "mdi:current-ac" },
+            "mainsctsphasecurrent": { "default": "mdi:current-ac" },
+            "mainscttphasecurrent": { "default": "mdi:current-ac" }
         },
         "switch": {
             "batteryequalizationenable": { "default": "mdi:equalizer" },
@@ -135,6 +154,10 @@
                 }
             },
             "recordfault": { "default": "mdi:alert" }
+        },
+        "time": {
+            "batteryequalizationstarttime": { "default": "mdi:equalizer" },
+            "batteryequalizationendtime": { "default": "mdi:equalizer" }
         }
     }
 }

--- a/custom_components/must_inverter/mapper.py
+++ b/custom_components/must_inverter/mapper.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from .const import INVERTER_ERROR, INVERTER_WARNING, CHARGER_ERROR, CHARGER_WARNING
@@ -25,12 +26,20 @@ def accumulated_kwh(address, registers):
     return registers[address] * 1000 + registers[address + 1] * 0.1
 
 
-def time(address, registers):
+def duration(address, registers):
     return int(registers[address]) * 60 * 60 + int(registers[address + 1]) * 60 + int(registers[address + 2])
+
+
+def time(address, registers):
+    return datetime.time(registers[address] // 100, registers[address] % 100)
 
 
 def serial(address, registers):
     return registers[address] << 16 | registers[address + 1]
+
+
+def serial_string(address, registers):
+    return f"{registers[address]:05d}{registers[address + 1]:05d}{registers[address + 2]:05d}"
 
 
 def model(address, registers):
@@ -106,7 +115,7 @@ def convert_partArr3(partArr3):
     result["BattVolGrade"] =         int16(15215, partArr3)
     result["RatedCurrent"] =         int16(15216, partArr3)
     result["AccumulatedPower"] =     accumulated_kwh(15217, partArr3)
-    result["AccumulatedTime"] =      time(15219, partArr3)
+    result["AccumulatedTime"] =      duration(15219, partArr3)
     # fmt: on
 
     return result
@@ -262,4 +271,123 @@ def convert_pv_data(registers):
             result["PV2ChargerPower"] = registers[16208]
     except Exception as e:
         _LOGGER.debug("PV data not available: %s", e)
+    return result
+
+
+def convert_ph1100_partArr1(partArr1):
+    if partArr1 is None:
+        return None
+
+    # fmt: off
+    result = {}
+    result["BatteryEqualizationInterval"] =  int16(10117, partArr1)
+    result["BatteryEqualizationStartTime"] = time(10118, partArr1)
+    result["BatteryEqualizationEndTime"] =   time(10119, partArr1)
+    # fmt: on
+
+    return result
+
+
+def convert_ph1100_partArr2(partArr2):
+    if partArr2 is None:
+        return None
+
+    # fmt: off
+    result = {}
+    result["BatteryVoltage"] =         int16(15104, partArr2)
+    result["BattCurrent"] =            int16(15105, partArr2)
+    result["BattPower"] =              int16(15106, partArr2)
+    result["InverterTemperature"] =    int16(15107, partArr2)
+    result["DcRadiatorTemperature"] =  int16(15108, partArr2)
+    result["TransformerTemperature"] = int16(15109, partArr2)
+    result["AmbientTemperature"] =     int16(15110, partArr2)
+    result["BatteryTemperature"] =     int16(15111, partArr2)
+    result["BMSVoltage"] =             int16(15112, partArr2)
+    result["BMSCurrent"] =             int16(15113, partArr2)
+    result["BMSTemperature"] =         int16(15114, partArr2)
+    result["BMSStateOfCharge"] =       int16(15115, partArr2)
+    result["BMSMaxCVSet"] =            int16(15116, partArr2)
+    result["BMSMaxCCSet"] =            int16(15117, partArr2)
+    result["BMSDisCVSet"] =            int16(15118, partArr2)
+    result["BMSDisCCSet"] =            int16(15119, partArr2)
+    # fmt: on
+
+    return result
+
+
+def convert_ph1100_partArr3(partArr3):
+    if partArr3 is None:
+        return None
+
+    # fmt: off
+    result = {}
+    result["InverterSerialNumber"] = serial_string(20001, partArr3)
+    # fmt: on
+
+    return result
+
+
+def convert_ph1100_partArr4(partArr4):
+    if partArr4 is None:
+        return None
+
+    # fmt: off
+    result = {}
+    result["PV1Voltage"] =                   int16(25225, partArr4)
+    result["PV1Current"] =                   int16(25226, partArr4)
+    result["PV1Power"] =                     int16(25227, partArr4)
+    result["PV2Voltage"] =                   int16(25228, partArr4)
+    result["PV2Current"] =                   int16(25229, partArr4)
+    result["PV2Power"] =                     int16(25230, partArr4)
+    result["PV3Voltage"] =                   int16(25231, partArr4)
+    result["PV3Current"] =                   int16(25232, partArr4)
+    result["PV3Power"] =                     int16(25233, partArr4)
+    result["PV4Voltage"] =                   int16(25234, partArr4)
+    result["PV4Current"] =                   int16(25235, partArr4)
+    result["PV4Power"] =                     int16(25236, partArr4)
+    result["GridVoltageR"] =                 int16(25237, partArr4)
+    result["GridVoltageS"] =                 int16(25238, partArr4)
+    result["GridVoltageT"] =                 int16(25239, partArr4)
+    result["GridCurrentR"] =                 int16(25240, partArr4)
+    result["GridCurrentS"] =                 int16(25241, partArr4)
+    result["GridCurrentT"] =                 int16(25242, partArr4)
+    result["GridFrequency"] =                int16(25243, partArr4)
+    result["PGrid"] =                        int16(25244, partArr4)
+    result["QGrid"] =                        int16(25245, partArr4)
+    result["SGrid"] =                        int16(25246, partArr4)
+    result["InverterVoltageR"] =             int16(25247, partArr4)
+    result["InverterVoltageS"] =             int16(25248, partArr4)
+    result["InverterVoltageT"] =             int16(25249, partArr4)
+    result["InverterCurrentR"] =             int16(25250, partArr4)
+    result["InverterCurrentS"] =             int16(25251, partArr4)
+    result["InverterCurrentT"] =             int16(25252, partArr4)
+    result["InverterFrequency"] =            int16(25253, partArr4)
+    result["PInverter"] =                    int16(25254, partArr4)
+    result["QInverter"] =                    int16(25255, partArr4)
+    result["SInverter"] =                    int16(25256, partArr4)
+    result["LoadVoltageR"] =                 int16(25257, partArr4)
+    result["LoadVoltageS"] =                 int16(25258, partArr4)
+    result["LoadVoltageT"] =                 int16(25259, partArr4)
+    result["LoadCurrentR"] =                 int16(25260, partArr4)
+    result["LoadCurrentS"] =                 int16(25261, partArr4)
+    result["LoadCurrentT"] =                 int16(25262, partArr4)
+    result["PLoad"] =                        int16(25263, partArr4)
+    result["QLoad"] =                        int16(25264, partArr4)
+    result["SLoad"] =                        int16(25265, partArr4)
+    result["MainsCTRPhaseCurrent"] =         int16(25284, partArr4)
+    result["MainsCTSPhaseCurrent"] =         int16(25285, partArr4)
+    result["MainsCTTPhaseCurrent"] =         int16(25286, partArr4)
+    result["MainsPowerCT"] =                 int16(25287, partArr4)
+    result["TotalPvEnergy"] =                accumulated_kwh(25310, partArr4)
+    result["TotalLoadEnergy"] =              accumulated_kwh(25312, partArr4)
+    result["TotalBatteryChargeEnergy"] =     accumulated_kwh(25314, partArr4)
+    result["TotalBatteryDischargeEnergy"] =  accumulated_kwh(25316, partArr4)
+    result["TotalInverterChargeEnergy"] =    accumulated_kwh(25318, partArr4)
+    result["TotalInverterDischargeEnergy"] = accumulated_kwh(25320, partArr4)
+    result["TotalGridChargeEnergy"] =        accumulated_kwh(25322, partArr4)
+    result["TotalGridDischargeEnergy"] =     accumulated_kwh(25324, partArr4)
+    result["TotalMainsChargeEnergyCT"] =     accumulated_kwh(25336, partArr4)
+    result["TotalMainsDischargeEnergyCT"] =  accumulated_kwh(25338, partArr4)
+    # fmt: on
+
     return result

--- a/custom_components/must_inverter/mapper.py
+++ b/custom_components/must_inverter/mapper.py
@@ -377,7 +377,7 @@ def convert_ph1100_partArr4(partArr4):
     result["MainsCTRPhaseCurrent"] =         int16(25284, partArr4)
     result["MainsCTSPhaseCurrent"] =         int16(25285, partArr4)
     result["MainsCTTPhaseCurrent"] =         int16(25286, partArr4)
-    result["MainsPowerCT"] =                 -int16(25287, partArr4) # Inverting for compatibility with HA home energy management grid power sensor spec
+    result["MainsPowerCT"] =                 int16(25287, partArr4)
     result["TotalPvEnergy"] =                accumulated_kwh(25310, partArr4)
     result["TotalLoadEnergy"] =              accumulated_kwh(25312, partArr4)
     result["TotalBatteryChargeEnergy"] =     accumulated_kwh(25314, partArr4)

--- a/custom_components/must_inverter/mapper.py
+++ b/custom_components/must_inverter/mapper.py
@@ -377,7 +377,7 @@ def convert_ph1100_partArr4(partArr4):
     result["MainsCTRPhaseCurrent"] =         int16(25284, partArr4)
     result["MainsCTSPhaseCurrent"] =         int16(25285, partArr4)
     result["MainsCTTPhaseCurrent"] =         int16(25286, partArr4)
-    result["MainsPowerCT"] =                 int16(25287, partArr4)
+    result["MainsPowerCT"] =                 -int16(25287, partArr4) # Inverting for compatibility with HA home energy management grid power sensor spec
     result["TotalPvEnergy"] =                accumulated_kwh(25310, partArr4)
     result["TotalLoadEnergy"] =              accumulated_kwh(25312, partArr4)
     result["TotalBatteryChargeEnergy"] =     accumulated_kwh(25314, partArr4)

--- a/custom_components/must_inverter/switch.py
+++ b/custom_components/must_inverter/switch.py
@@ -6,7 +6,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import Platform
 from homeassistant.core import callback
 
-from .const import DOMAIN, Sensor
+from .const import DOMAIN, MODEL_PH1100, Sensor
 from .__init__ import MustInverter
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,23 +24,26 @@ _system_settings_lock = asyncio.Lock()
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    # fmt: off
-    settings = [
-        Setting(0, "OverLoadRestart",  True,  True),
-        Setting(1, "OverTempRestart",  True,  True),
-        Setting(2, "OverLoadBypass",   True,  True),
-        Setting(3, "AutoTurnPage",     True,  True),
-        Setting(4, "GridBuzz",         False, True),
-        Setting(5, "Buzz",             True,  True),
-        Setting(6, "LcdLight",         False, True),
-        Setting(7, "RecordFault",      True,  True),
-    ]
-    # fmt: on
-
     inverter_data = hass.data[DOMAIN][entry.entry_id]
     inverter = inverter_data["inverter"]
     sensors = inverter_data["sensors"]
     entities = []
+
+    if inverter.model == MODEL_PH1100:
+        settings = []
+    else:
+        # fmt: off
+        settings = [
+            Setting(0, "OverLoadRestart",  True,  True),
+            Setting(1, "OverTempRestart",  True,  True),
+            Setting(2, "OverLoadBypass",   True,  True),
+            Setting(3, "AutoTurnPage",     True,  True),
+            Setting(4, "GridBuzz",         False, True),
+            Setting(5, "Buzz",             True,  True),
+            Setting(6, "LcdLight",         False, True),
+            Setting(7, "RecordFault",      True,  True),
+        ]
+        # fmt: on
 
     for setting in settings:
         entities.append(MustInverterSettingsSwitch(inverter, setting))

--- a/custom_components/must_inverter/time.py
+++ b/custom_components/must_inverter/time.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Any
+from datetime import time
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.core import callback
+from homeassistant.const import Platform
+
+from .const import DOMAIN, Sensor
+from .__init__ import MustInverter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    inverter_data = hass.data[DOMAIN][entry.entry_id]
+    inverter = inverter_data["inverter"]
+    sensors = inverter_data["sensors"]
+    entities = []
+
+    for sensor_info in sensors:
+        if sensor_info.platform == Platform.TIME:
+            sensor = MustInverterTime(inverter, sensor_info)
+            entities.append(sensor)
+
+    async_add_entities(entities)
+    return True
+
+
+class MustInverterTime(TimeEntity):
+    def __init__(self, inverter: MustInverter, sensor_info: Sensor):
+        """Initialize the sensor."""
+        self._inverter = inverter
+        self._key = sensor_info.name
+        self._address = sensor_info.address
+
+        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{self._inverter.data['InverterSerialNumber']}_{self._key}"
+        self._attr_translation_key = self._key.lower()
+        self._attr_entity_registry_enabled_default = sensor_info.enabled
+
+    async def async_added_to_hass(self):
+        self._inverter.async_add_must_inverter_sensor(self._inverter_data_updated)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._inverter.async_remove_must_inverter_sensor(self._inverter_data_updated)
+
+    @callback
+    def _inverter_data_updated(self):
+        self.async_write_ha_state()
+
+    @property
+    def state(self):
+        if self._key in self._inverter.data:
+            return self._inverter.data[self._key]
+
+    async def async_set_value(self, value: time) -> None:
+        integer = value.hour * 100 + value.minute
+
+        await self._inverter.write_modbus_data(self._address, integer)
+        if self._key in self._inverter.data:
+            self._inverter.data[self._key] = value  # optmiistic update
+
+    @property
+    def device_info(self) -> dict[str, Any] | None:
+        return self._inverter._device_info()
+
+    @property
+    def available(self) -> dict[str, Any] | None:
+        return self._key in self._inverter.data

--- a/custom_components/must_inverter/translations/en.json
+++ b/custom_components/must_inverter/translations/en.json
@@ -156,7 +156,8 @@
       "options": {
         "autodetect": "Auto Detect",
         "pv1800": "PV1800 Series",
-        "pv1900": "PV1900 Series"
+        "pv1900": "PV1900 Series",
+        "ph1100": "PH1100 Series"
       }
     },
     "mode": {
@@ -290,6 +291,17 @@
       "batteryvoltage": { "name": "Battery Voltage" },
       "chargercurrent": { "name": "Charger Current" },
       "chargerpower": { "name": "Charger Power" },
+      "invertertemperature": { "name": "Inverter Temperature" },
+      "ambienttemperature": { "name": "Ambient Temperature" },
+      "batterytemperature": { "name": "Battery Temperature" },
+      "bmsvoltage": { "name": "BMS Voltage" },
+      "bmscurrent": { "name": "BMS Current" },
+      "bmstemperature": { "name": "BMS Temperature" },
+      "bmsstateofcharge": { "name": "BMS State Of Charge" },
+      "bmsmaxcvset": { "name": "BMS Max Charge Voltage Set" },
+      "bmsmaxccset": { "name": "BMS Max Charge Current Set" },
+      "bmsdiscvset": { "name": "BMS Discharge Voltage Set" },
+      "bmsdisccset": { "name": "BMS Discharge Current Set" },
       "radiatortemperature": { "name": "Radiator Temperature" },
       "externaltemperature": { "name": "External Temperature" },
       "chargererrormessage": { "name": "Error Message (Charger)" },
@@ -362,7 +374,51 @@
       "pv1chargercurrent": { "name": "PV1 Charger Current" },
       "pv1chargerpower": { "name": "PV1 Charger Power" },
       "pv2chargercurrent": { "name": "PV2 Charger Current" },
-      "pv2chargerpower": { "name": "PV2 Charger Power" }
+      "pv2chargerpower": { "name": "PV2 Charger Power" },
+      "pv1voltage": { "name": "PV1 Voltage" },
+      "pv1current": { "name": "PV1 Current" },
+      "pv1power": { "name": "PV1 Power" },
+      "pv2voltage": { "name": "PV2 Voltage" },
+      "pv2current": { "name": "PV2 Current" },
+      "pv2power": { "name": "PV2 Power" },
+      "pv3voltage": { "name": "PV3 Voltage" },
+      "pv3current": { "name": "PV3 Current" },
+      "pv3power": { "name": "PV3 Power" },
+      "pv4voltage": { "name": "PV4 Voltage" },
+      "pv4current": { "name": "PV4 Current" },
+      "pv4power": { "name": "PV4 Power" },
+      "gridvoltager": { "name": "Grid Voltage R" },
+      "gridvoltages": { "name": "Grid Voltage S" },
+      "gridvoltaget": { "name": "Grid Voltage T" },
+      "gridcurrentr": { "name": "Grid Current R" },
+      "gridcurrents": { "name": "Grid Current S" },
+      "gridcurrentt": { "name": "Grid Current T" },
+      "invertervoltager": { "name": "Inverter Voltage R" },
+      "invertervoltages": { "name": "Inverter Voltage S" },
+      "invertervoltaget": { "name": "Inverter Voltage T" },
+      "invertercurrentr": { "name": "Inverter Current R" },
+      "invertercurrents": { "name": "Inverter Current S" },
+      "invertercurrentt": { "name": "Inverter Current T" },
+      "loadvoltager": { "name": "Load Voltage R" },
+      "loadvoltages": { "name": "Load Voltage S" },
+      "loadvoltaget": { "name": "Load Voltage T" },
+      "loadcurrentr": { "name": "Load Current R" },
+      "loadcurrents": { "name": "Load Current S" },
+      "loadcurrentt": { "name": "Load Current T" },
+      "mainsctrphasecurrent": { "name": "Mains CT-R Phase Current" },
+      "mainsctsphasecurrent": { "name": "Mains CT-S Phase Current" },
+      "mainscttphasecurrent": { "name": "Mains CT-T Phase Current" },
+      "mainspowerct": { "name": "Mains Power CT" },
+      "totalpvenergy": { "name": "Total PV Energy" },
+      "totalloadenergy": { "name": "Total Load Energy" },
+      "totalbatterychargeenergy": { "name": "Total Battery Charge Energy" },
+      "totalbatterydischargeenergy": { "name": "Total Battery Discharge Energy" },
+      "totalinverterchargeenergy": { "name": "Total Inverter Charge Energy" },
+      "totalinverterdischargeenergy": { "name": "Total Inverter Discharge Energy" },
+      "totalgridchargeenergy": { "name": "Total Grid Charge Energy" },
+      "totalgriddischargeenergy": { "name": "Total Grid Discharge Energy" },
+      "totalmainschargeenergyct": { "name": "Total Mains Charge Energy (CT)" },
+      "totalmainsdischargeenergyct": { "name": "Total Mains Discharge Energy (CT)" }
     },
     "switch": {
       "chargerworkenable": { "name": "Charger" },
@@ -383,6 +439,10 @@
       "buzz": { "name": "Buzz" },
       "lcdlight": { "name": "LCD Light" },
       "recordfault": { "name": "Record Fault" }
+    },
+    "time": {
+      "batteryequalizationstarttime": { "name": "Battery Equalization Start Time" },
+      "batteryequalizationendtime": { "name": "Battery Equalization End Time" }
     }
   }
 }


### PR DESCRIPTION
This pull request adds support for the PH1100 series. Developed using a [PH1100 EU Series (AC:380V 5-12KW)](https://www.mustsolar.com/product/ph1100-eu-series-ac380v-5-12kw/) inverter.

# Changes
- Added support for the PH1100 series
- Added the `TIME` platform sensor
- Changed device info retrieval to support inverters with missing `InverterMachineType`, `InverterHardwareVersion` or `InverterSoftwareVersion` values

# Notes
- Auto Detect doesn't work for this model as I haven't found a register containing the model name. Maybe UI should be updated to reflect that?
- Most of the input sensors have not been implemented as I don't know the valid ranges for them. Ranges are not included in the manual and I don't want to mess with the inverter's settings.
- Names of the sensors are based on the official [SmartValue](https://play.google.com/store/apps/details?id=com.eybond.smartvalue) app, inverter's manual, and the inverter's touch panel interface, with slight corrections.