### PR TITLE
feat: configurable modbus device id

### DIFF
--- a/custom_components/must_inverter/__init__.py
+++ b/custom_components/must_inverter/__init__.py
@@ -32,7 +32,9 @@ from .const import (
     CONF_RETRIES,
     CONF_RECONNECT_DELAY,
     CONF_RECONNECT_DELAY_MAX,
+    CONF_DEVICE_ID,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_DEVICE_ID,
     get_sensors_for_model,
     MODEL_PV1900,
     MODEL_PH1100,
@@ -180,6 +182,7 @@ class MustInverter:
         self._client.rts = False
         self._client.dtr = False
         self._lock = asyncio.Lock()
+        self._device_id = entry.options.get(CONF_DEVICE_ID, DEFAULT_DEVICE_ID)
         self._scan_interval = timedelta(seconds=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
         self._reading = False
         self.registers = {}
@@ -275,7 +278,7 @@ class MustInverter:
 
         _LOGGER.debug("writing modbus data: %s %s", address, value)
         async with self._lock:
-            response = await self._client.write_register(address=address, value=value, device_id=0x04)
+            response = await self._client.write_register(address=address, value=value, device_id=self._device_id)
 
         if response.isError():
             _LOGGER.error("error writing modbus data: %s", response)
@@ -348,7 +351,9 @@ class MustInverter:
                     break
 
                 async with self._lock:
-                    response = await self._client.read_holding_registers(address=start, count=count, device_id=0x04)
+                    response = await self._client.read_holding_registers(
+                        address=start, count=count, device_id=self._device_id
+                    )
                 if response.isError():
                     _LOGGER.error("error reading modbus data at address %s: %s", start, response)
                 elif len(response.registers) != count:

--- a/custom_components/must_inverter/config_flow.py
+++ b/custom_components/must_inverter/config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 from .const import (
     DOMAIN,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_DEVICE_ID,
     SUPPORTED_MODELS,
     CONF_BAUDRATE,
     CONF_PARITY,
@@ -29,6 +30,7 @@ from .const import (
     CONF_RETRIES,
     CONF_RECONNECT_DELAY,
     CONF_RECONNECT_DELAY_MAX,
+    CONF_DEVICE_ID,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,6 +91,7 @@ MODBUS_SCHEMA = vol.Schema(
         vol.Required(CONF_RETRIES, default=3): int,
         vol.Required(CONF_RECONNECT_DELAY, default=0.3): vol.Coerce(float),
         vol.Required(CONF_RECONNECT_DELAY_MAX, default=1.0): vol.Coerce(float),
+        vol.Required(CONF_DEVICE_ID, default=DEFAULT_DEVICE_ID): int,
     }
 )
 

--- a/custom_components/must_inverter/const.py
+++ b/custom_components/must_inverter/const.py
@@ -13,8 +13,10 @@ CONF_BYTESIZE = "bytesize"
 CONF_RETRIES = "retries"
 CONF_RECONNECT_DELAY = "reconnect_delay"
 CONF_RECONNECT_DELAY_MAX = "reconnect_delay_max"
+CONF_DEVICE_ID = "device_id"
 
 DEFAULT_SCAN_INTERVAL = 15
+DEFAULT_DEVICE_ID = 0x04
 
 # model constants, needs to be lowercase otherwise hassfest checks fails...
 MODEL_PV1800 = "pv1800"  # Base model

--- a/custom_components/must_inverter/translations/en.json
+++ b/custom_components/must_inverter/translations/en.json
@@ -50,12 +50,14 @@
         "title": "PyModbus advanced settings",
         "description": "Leave this section unchanged unless you are seeing connection issues or need to adjust the modbus connection settings.",
         "data": {
+          "device_id": "Device ID",
           "timeout": "Timeout (seconds)",
           "retries": "Retries",
           "reconnect_delay": "Reconnect Delay (seconds)",
           "reconnect_delay_max": "Max Reconnect Delay (seconds)"
         },
         "data_description": {
+          "device_id": "The Modbus device ID (slave address) of the inverter. Default is 4 (0x04). Use this option only when there are multiple inverters connected to the same serial port (such as in cases of inverters running in parallel)",
           "timeout": "Timeout for connecting and receiving data.",
           "retries": "Max number of retries per request.",
           "reconnect_delay": "Minimum delay before reconnecting. Set to 0 to disable reconnecting.",
@@ -114,12 +116,14 @@
         "title": "PyModbus advanced settings",
         "description": "Leave this section unchanged unless you are seeing connection issues or need to adjust the modbus connection settings.",
         "data": {
+          "device_id": "Device ID",
           "timeout": "Timeout (seconds)",
           "retries": "Retries",
           "reconnect_delay": "Reconnect Delay (seconds)",
           "reconnect_delay_max": "Max Reconnect Delay (seconds)"
         },
         "data_description": {
+          "device_id": "The Modbus device ID (slave address) of the inverter. Default is 4 (0x04). Use this option only when there are multiple inverters connected to the same serial port (such as in cases of inverters running in parallel)",
           "timeout": "Timeout for connecting and receiving data.",
           "retries": "Max number of retries per request.",
           "reconnect_delay": "Minimum delay before reconnecting. Set to 0 to disable reconnecting.",

--- a/custom_components/must_inverter/translations/pt-BR.json
+++ b/custom_components/must_inverter/translations/pt-BR.json
@@ -50,12 +50,14 @@
         "title": "Configurações avançadas do PyModbus",
         "description": "Deixe esta seção inalterada, a menos que você esteja tendo problemas de conexão ou precise ajustar as configurações de conexão do modbus.",
         "data": {
+          "device_id": "ID do dispositivo",
           "timeout": "Timeout (segundos)",
           "retries": "Tentativas",
           "reconnect_delay": "Delay de reconexão (segundos)",
           "reconnect_delay_max": "Delay máximo de reconexão (segundos)"
         },
         "data_description": {
+          "device_id": "O ID do dispositivo Modbus (slave address) do inversor. O padrão é 4 (0x04). Use esta opção somente quando existirem mais de um inversor conectados à mesma porta serial (como nos casos de inversores em paralelo)",
           "timeout": "Tempo limite para conectar e receber dados.",
           "retries": "Número máximo de tentativas por solicitação.",
           "reconnect_delay": "Delay mínimo antes de reconectar. Defina como 0 para desativar a reconexão.",
@@ -114,12 +116,14 @@
         "title": "Configurações avançadas do PyModbus",
         "description": "Deixe esta seção inalterada, a menos que você esteja tendo problemas de conexão ou precise ajustar as configurações de conexão do modbus.",
         "data": {
+          "device_id": "ID do dispositivo",
           "timeout": "Timeout (segundos)",
           "retries": "Tentativas",
           "reconnect_delay": "Delay de reconexão (segundos)",
           "reconnect_delay_max": "Delay máximo de reconexão (segundos)"
         },
         "data_description": {
+          "device_id": "O ID do dispositivo Modbus (slave address) do inversor. O padrão é 4 (0x04). Use esta opção somente quando existirem mais de um inversor conectados à mesma porta serial (como nos casos de inversores em paralelo)",
           "timeout": "Tempo limite para conectar e receber dados.",
           "retries": "Número máximo de tentativas por solicitação.",
           "reconnect_delay": "Delay mínimo antes de reconectar. Defina como 0 para desativar a reconexão.",

--- a/custom_components/must_inverter/utils/register_monitor.py
+++ b/custom_components/must_inverter/utils/register_monitor.py
@@ -52,7 +52,9 @@ class RegisterMonitor:
                         break
 
                     async with inverter._lock:
-                        response = await inverter._client.read_holding_registers(address=start, count=count, device_id=0x04)
+                        response = await inverter._client.read_holding_registers(
+                            address=start, count=count, device_id=inverter._device_id
+                        )
 
                     if response.isError():
                         _LOGGER.warning(f"Error reading range {start}-{end}: {response}")


### PR DESCRIPTION
This pull request adds support for configuring the Modbus device ID (slave address) for Must Inverter integrations, making it possible to use the integration with multiple inverters on the same serial port. The device ID is now configurable via the UI, is used throughout all Modbus read/write operations, and is documented in both English and Portuguese translations.

**Configurable Device ID Support**

* Added a new configuration option `device_id` (with default value `0x04`) to the integration, allowing users to set the Modbus device ID for their inverter. This is now included in the options schema and configuration flow (`const.py`, `config_flow.py`). [[1]](diffhunk://#diff-429c73a9a4778f8477c596a814b8373e269fa805ce7474ec3756e56c128cf72dR16-R19) [[2]](diffhunk://#diff-429c73a9a4778f8477c596a814b8373e269fa805ce7474ec3756e56c128cf72dR16-R19) [[3]](diffhunk://#diff-b3c0f78ccfff2ee82319804ffc389b016483b1d94c36cf36e092f43f7ccce077R24) [[4]](diffhunk://#diff-b3c0f78ccfff2ee82319804ffc389b016483b1d94c36cf36e092f43f7ccce077R33) [[5]](diffhunk://#diff-b3c0f78ccfff2ee82319804ffc389b016483b1d94c36cf36e092f43f7ccce077R94)
* Updated the inverter client initialization to use the configured `device_id` instead of a hardcoded value. All Modbus read and write operations now use this configurable device ID (`__init__.py`, `register_monitor.py`). [[1]](diffhunk://#diff-bd02ef5096ddfff72a3cc12a22cbe16c76d77f0694460e5d2c9171d6817c12b2R35-R37) [[2]](diffhunk://#diff-bd02ef5096ddfff72a3cc12a22cbe16c76d77f0694460e5d2c9171d6817c12b2R185) [[3]](diffhunk://#diff-bd02ef5096ddfff72a3cc12a22cbe16c76d77f0694460e5d2c9171d6817c12b2L278-R281) [[4]](diffhunk://#diff-bd02ef5096ddfff72a3cc12a22cbe16c76d77f0694460e5d2c9171d6817c12b2L351-R356) [[5]](diffhunk://#diff-dcd8ef4faca32eacc3ad1620652544142a7d67d484699f224eb57dc1008e36e3L55-R57)

**Documentation and Translations**

* Added and updated English and Portuguese translation files to include the new `device_id` option and its description, explaining its purpose and default value. [[1]](diffhunk://#diff-454264e4d393602bcb86fc701a54c8b77ff822b9c5568d2873f83bab8f208111R53-R60) [[2]](diffhunk://#diff-454264e4d393602bcb86fc701a54c8b77ff822b9c5568d2873f83bab8f208111R119-R126) [[3]](diffhunk://#diff-972a924cc84edb0df43d3b80a4e0d288c458f5b70e5d7adec68a40a4d2f4bf2aR53-R60) [[4]](diffhunk://#diff-972a924cc84edb0df43d3b80a4e0d288c458f5b70e5d7adec68a40a4d2f4bf2aR119-R126)