### PR TITLE
fix: close modbus client when config entry setup fails

### DIFF
--- a/custom_components/must_inverter/__init__.py
+++ b/custom_components/must_inverter/__init__.py
@@ -80,24 +80,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Initialize inverter with model-specific sensors
         inverter = MustInverter(hass, entry)
 
-        successConnecting = await inverter.connect()
+        try:
+            successConnecting = await inverter.connect()
 
-        if not successConnecting:
-            raise ConfigEntryNotReady("Unable to connect to modbus device")
+            if not successConnecting:
+                raise ConfigEntryNotReady("Unable to connect to modbus device")
 
-        successReading = await inverter._async_refresh_modbus_data()
+            successReading = await inverter._async_refresh_modbus_data()
 
-        if not successReading:
-            raise ConfigEntryNotReady("Unable to read from modbus device")
+            if not successReading:
+                raise ConfigEntryNotReady("Unable to read from modbus device")
 
-        model = inverter.model
-        sensors = get_sensors_for_model(model)
-        _LOGGER.debug("Setting up Must Inverter with model: %s", model)
+            model = inverter.model
+            sensors = get_sensors_for_model(model)
+            _LOGGER.debug("Setting up Must Inverter with model: %s", model)
 
-        # Store sensors to be used by platforms
-        hass.data[DOMAIN][entry.entry_id] = {"inverter": inverter, "sensors": sensors}
+            # Store sensors to be used by platforms
+            hass.data[DOMAIN][entry.entry_id] = {"inverter": inverter, "sensors": sensors}
 
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+            await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        except BaseException:
+            # A failed setup must never leave the serial port open: the leaked
+            # client keeps holding the exclusive port lock inside the running
+            # process, so every setup retry then fails with "Could not
+            # exclusively lock port" until Home Assistant is restarted.
+            inverter.close()
+            hass.data[DOMAIN].pop(entry.entry_id, None)
+            raise
 
         # Removing register monitor as we've found all needed registers
         # If you need to add it back, uncomment the following lines and set the ranges to scan in register_monitor.py
@@ -391,6 +400,12 @@ class MustInverter:
         self.registers = read
         self._reading = False
         # _LOGGER.debug("Data: %s", self.data)
+
+        if "InverterSerialNumber" not in self.data:
+            # No register range could be read at all (e.g. the inverter is
+            # powered off) - report failure instead of raising KeyError below.
+            _LOGGER.warning("no data could be read from the inverter")
+            return False
 
         if self.data["InverterSerialNumber"] == 0xFFFFFFFF or self.data["InverterSerialNumber"] == 0:
             ir.async_create_issue(


### PR DESCRIPTION
## Problem

When `async_setup_entry` fails after a successful `connect()` — typically because the inverter is powered off and the initial `_async_refresh_modbus_data()` read times out — the `AsyncModbusSerialClient` is never closed. The leaked client keeps holding the exclusive lock on the serial port inside the running Home Assistant process, so every subsequent setup retry fails with:

```
WARNING [pymodbus.logging] Failed to connect [Errno 11] Could not exclusively lock port /dev/serial/by-id/usb-FTDI_...: [Errno 11] Resource temporarily unavailable
WARNING [custom_components.must_inverter] not able to connect to /dev/serial/by-id/usb-FTDI_...:0
```

The integration then can never recover on its own — not even after the inverter comes back — until Home Assistant is restarted *while the inverter is answering* (if it is still off, the first retry after restart wedges the port again). Reproduced on v0.2.5 / HA 2026.8.3 / PV1800 over an FTDI FT232R serial adapter.

Additionally, when no register range could be read at all, `read_modbus_data` raised `KeyError: 'InverterSerialNumber'` (line 395) instead of reporting failure, which surfaced as "Unknown error connecting to modbus device".

## Fix

- Wrap the connect/first-read/platform-setup phase of `async_setup_entry` and close the client on any failure before re-raising, so a failed setup never leaves the port locked and `ConfigEntryNotReady` retries can actually succeed once the inverter answers again.
- `read_modbus_data` returns `False` when nothing could be read instead of raising `KeyError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)